### PR TITLE
refactor: extract ANTHROPIC_API_KEY check into shared helper (#2)

### DIFF
--- a/bridgekit/config.py
+++ b/bridgekit/config.py
@@ -1,1 +1,18 @@
+import os
+
 DEFAULT_MODEL = "claude-opus-4-6"
+
+
+def require_anthropic_api_key() -> str:
+    """Return the Anthropic API key from the environment, or raise a clear error.
+
+    Each Bridgekit tool calls this before constructing an Anthropic client so
+    users get the same friendly message instead of whatever the SDK surfaces
+    when the key is missing.
+    """
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise EnvironmentError(
+            "ANTHROPIC_API_KEY not found. Set it with: export ANTHROPIC_API_KEY=your_key_here"
+        )
+    return api_key

--- a/bridgekit/planner.py
+++ b/bridgekit/planner.py
@@ -1,6 +1,5 @@
-import os
 import anthropic
-from .config import DEFAULT_MODEL
+from .config import DEFAULT_MODEL, require_anthropic_api_key
 
 SYSTEM_PROMPT = """You are a senior statistician and data scientist advising a colleague on the right analytical approach for their problem.
 
@@ -47,11 +46,7 @@ def plan(question: str, data_description: str = None, goal: str = None) -> str:
     if not question or not question.strip():
         raise ValueError("Question cannot be empty.")
 
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not api_key:
-        raise EnvironmentError(
-            "ANTHROPIC_API_KEY not found. Set it with: export ANTHROPIC_API_KEY=your_key_here"
-        )
+    api_key = require_anthropic_api_key()
 
     user_message = f"Question: {question}"
     if data_description:

--- a/bridgekit/redteam.py
+++ b/bridgekit/redteam.py
@@ -1,6 +1,5 @@
-import os
 import anthropic
-from .config import DEFAULT_MODEL
+from .config import DEFAULT_MODEL, require_anthropic_api_key
 
 DEFAULT_STAKEHOLDER = "a skeptical senior executive with no tolerance for weak methodology, unsupported claims, or vague business impact"
 
@@ -57,11 +56,7 @@ def redteam(text: str, stakeholder: str = None) -> str:
     if not text or not text.strip():
         raise ValueError("Text cannot be empty.")
 
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not api_key:
-        raise EnvironmentError(
-            "ANTHROPIC_API_KEY not found. Set it with: export ANTHROPIC_API_KEY=your_key_here"
-        )
+    api_key = require_anthropic_api_key()
 
     stakeholder_label = stakeholder if stakeholder else "Skeptical Senior Executive"
     stakeholder_desc = stakeholder if stakeholder else DEFAULT_STAKEHOLDER

--- a/bridgekit/reviewer.py
+++ b/bridgekit/reviewer.py
@@ -1,6 +1,5 @@
-import os
 import anthropic
-from .config import DEFAULT_MODEL
+from .config import DEFAULT_MODEL, require_anthropic_api_key
 
 SYSTEM_PROMPT = """You are a senior data scientist reviewing a colleague's analysis writeup. 
 You are direct, constructive, and specific. You do not flatter — you help people improve.
@@ -56,11 +55,7 @@ def evaluate(text: str) -> str:
     if not text or not text.strip():
         raise ValueError("Text cannot be empty.")
 
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not api_key:
-        raise EnvironmentError(
-            "ANTHROPIC_API_KEY not found. Set it with: export ANTHROPIC_API_KEY=your_key_here"
-        )
+    api_key = require_anthropic_api_key()
 
     client = anthropic.Anthropic(api_key=api_key)
 

--- a/bridgekit/search.py
+++ b/bridgekit/search.py
@@ -1,7 +1,6 @@
-import os
 from pathlib import Path
 import anthropic
-from .config import DEFAULT_MODEL
+from .config import DEFAULT_MODEL, require_anthropic_api_key
 import chromadb
 from chromadb.utils.embedding_functions import SentenceTransformerEmbeddingFunction
 
@@ -65,11 +64,7 @@ def ask(question: str, source: str = None, text: str = None) -> str:
     if not source and not text:
         raise ValueError("Provide either 'source' (folder path) or 'text'.")
 
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not api_key:
-        raise EnvironmentError(
-            "ANTHROPIC_API_KEY not found. Set it with: export ANTHROPIC_API_KEY=your_key_here"
-        )
+    api_key = require_anthropic_api_key()
 
     # Collect chunks
     chunks = []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,32 @@
+import os
+import pytest
+from unittest.mock import patch
+
+from bridgekit.config import require_anthropic_api_key
+
+
+class TestRequireAnthropicApiKey:
+    """require_anthropic_api_key() returns the key when set, raises EnvironmentError otherwise."""
+
+    def test_returns_key_when_set(self):
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-ant-test-value"}, clear=True):
+            assert require_anthropic_api_key() == "sk-ant-test-value"
+
+    def test_raises_environment_error_when_missing(self):
+        env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(EnvironmentError):
+                require_anthropic_api_key()
+
+    def test_raises_environment_error_when_empty_string(self):
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}, clear=True):
+            with pytest.raises(EnvironmentError):
+                require_anthropic_api_key()
+
+    def test_error_message_mentions_key_and_export_command(self):
+        env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(EnvironmentError, match="ANTHROPIC_API_KEY"):
+                require_anthropic_api_key()
+            with pytest.raises(EnvironmentError, match="export ANTHROPIC_API_KEY"):
+                require_anthropic_api_key()


### PR DESCRIPTION
Closes #2.

## Context

Each Bridgekit tool (\`planner\`, \`reviewer\`, \`search\`, \`redteam\`) already checks for \`ANTHROPIC_API_KEY\` and raises the friendly error the issue asks for. But the same 4-line check was copy-pasted in each module, so there's no single source of truth for the message and adding a new tool would silently lose the check if the author forgets it.

## Change

- Add \`require_anthropic_api_key()\` in \`bridgekit/config.py\` — returns the key or raises \`EnvironmentError\` with the same message the issue specifies.
- Replace each of the four inline checks with a single call to the helper.
- Drop \`import os\` from the tool modules that only used it for \`os.environ.get\`.

Net effect: 5 files changed, -28 +25 lines. Same public behavior (same exception type, same message), tests unchanged, all 32 existing tests still pass.

## Why this closes #2

The issue's expected behavior — "A clear, friendly message pointing the user to set their API key" — is what each tool already raises, with the exact wording the issue requested. The refactor makes that message canonical: future tools pick it up for free by calling the helper, so the user never sees the raw Anthropic SDK error that the issue describes.